### PR TITLE
Add new insert method

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,11 @@ BufferPut.prototype.put = function(buf) {
   return this;
 };
 
+BufferPut.prototype.insert = function(bufferput) {
+  this.words = this.words.concat(bufferput.words);
+  this.len += bufferput.len;
+}
+
 BufferPut.prototype.word8 = function(x) {
   this.words.push({bytes: 1, value: x});
   this.len += 1;


### PR DESCRIPTION
the proposed `insert` method can be used to insert in-place an already prepared BufferPut instance, while not starting the buffer marshalling.

```
buf.insert(bufferput)
```

instead of

```
buf.put(bufferput.buffer())
```
